### PR TITLE
Fix typo in profile ranks comment

### DIFF
--- a/views/profile.ejs
+++ b/views/profile.ejs
@@ -91,7 +91,7 @@
          
          // if a user switch_state is true
          // the author verifiedDetails.authorRank will show one of five levels
-         // Dangerous, Cautioned, Creditble, Reliable and Genuine
+        // Dangerous, Cautioned, Credible, Reliable and Genuine
          // we want bootstrap colors danger, warning, secondary, success and primary to relate to each state
          // we want a short javascript function that returns the css class to be added to rounded-circle
          // in order to set the color of this user's photo border to their proper color


### PR DESCRIPTION
## Summary
- fix a spelling mistake in the profile rank comment

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6841aeddae4c833397157c71a63f095a